### PR TITLE
Support starting animation before being added to window

### DIFF
--- a/MaterialActivityIndicator/Classes/MaterialActivityIndicator.swift
+++ b/MaterialActivityIndicator/Classes/MaterialActivityIndicator.swift
@@ -53,6 +53,12 @@ public class MaterialActivityIndicatorView: UIView {
         indicator.strokeEnd = 0.0
         layer.addSublayer(indicator)
     }
+
+    public override func didMoveToWindow() {
+        if window != nil && isAnimating {
+            animator.addAnimation(to: indicator)
+        }
+    }
 }
 
 extension MaterialActivityIndicatorView {
@@ -75,7 +81,9 @@ extension MaterialActivityIndicatorView {
     public func startAnimating() {
         guard !isAnimating else { return }
 
-        animator.addAnimation(to: indicator)
+        if window != nil {
+            animator.addAnimation(to: indicator)
+        }
         isAnimating = true
     }
 


### PR DESCRIPTION
If the view is not on the screen (window == nil), defer adding animation to activity indicator until it gets added to window.

This patch allows to call `startAnimating()` while setting up the view, so that it starts animating immediately after going on-screen. Up until now, in order to take effect, `startAnimating()` had to be called when the view was already on-screen.

This is important in use cases when you create a view first, and then pass it on to the caller as a part of a view controller without exposing the activity indicator in VC's API (think showing a ready-made "waiting" dialog to the user).